### PR TITLE
Ignore padding tokens when generating text

### DIFF
--- a/megatron/text_generation_utils.py
+++ b/megatron/text_generation_utils.py
@@ -381,6 +381,8 @@ def sample_sequence_batch(model, context_tokens, context_lengths,
                                            forward_method_parallel_output=False)
                 logits = logits[:, -1].view(batch_size, -1).contiguous()
 
+            # Ignore padding tokens
+            logits = logits[:, :tokenizer.vocab_size]
             if args.greedy:
                 prev = torch.argmax(logits, dim=-1).view(-1)
             else:


### PR DESCRIPTION
To ensure that the vocabulary can be evenly divided across all the GPUs that the model is split across, and also apparently for some efficiency reasons I don't fully understand, MegatronLM adds padding tokens to the model. But these padding tokens do not correspond to any real tokens in the vocabulary, and thus can't even be decoded. The current version of the text generation code allows these tokens to be selected during generation, which causes an exception to be thrown.

This corresponds to one of the two issues originally fixed in https://github.com/gcooper-isi/DeepSpeedExamples/pull/19/files

NVIDIA has already fixed the other issue addressed in that other pull request (that generation was only using the tokens for the first GPU within each data parallel group when generating text).